### PR TITLE
Modernize Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,27 +1,48 @@
-name: Build and Deploy
+name: Deploy to GitHub Pages
+
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+  workflow_dispatch:
+
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
-    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎
+      - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Node env 🏗
+      - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           cache: 'npm'
-      - name: Install dependencies 👨🏻‍💻
+      - name: Install dependencies
         run: npm ci
-      - name: Run Build 🔧
+      - name: Build
         run: npm run build
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: dist
+          path: ./dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replaces JamesIves/github-pages-deploy-action with GitHub's first-party Pages actions: actions/configure-pages, actions/upload-pages-artifact, and actions/deploy-pages.

Benefits:
- No gh-pages branch — the artifact uploads directly to Pages infrastructure, keeping the repo clean.
- OIDC-based deploy (no contents:write needed; no commits to the repo from the deploy bot).
- First-party + actively maintained.
- Cleaner deployment status reporting (live URL on each run).